### PR TITLE
Set editor path to be newly cloned repo

### DIFF
--- a/opentracing-tutorial-lesson01/index.json
+++ b/opentracing-tutorial-lesson01/index.json
@@ -34,6 +34,7 @@
   ],
   "environment": {
     "uilayout": "editor-terminal",
+    "uieditorpath": "/root/opentracing-tutorial",
     "showdashboard": true,
     "dashboards": [{"name": "Jaeger UI", "port": 16686}]
   },


### PR DESCRIPTION
By default the editor displays `/root/`

This PR will point the editor to just the opentracing repo.

We can't do to just /java/ as Git complains the folder is not empty.